### PR TITLE
fix Name type columns to string - closes #13

### DIFF
--- a/pybbg/pybbg_k.py
+++ b/pybbg/pybbg_k.py
@@ -228,7 +228,7 @@ class Pybbg():
                 override1.setElement('value', overrides[k])
 
         
-        print(request)
+        # print(request)
         self.session.sendRequest(request)
         data = dict()
 
@@ -243,7 +243,7 @@ class Pybbg():
                     for i, row in enumerate(fieldData.values()):
                         for j in range(row.numElements()):
                             e = row.getElement(j)
-                            k = e.name()
+                            k = str(e.name())
                             v = e.getValue()
                             if k not in data:
                                 data[k] = list()

--- a/test_pybbg.py
+++ b/test_pybbg.py
@@ -13,6 +13,11 @@ class TestPybbg(unittest.TestCase):
         data = tester.bds('EDA Comdty', 'OPT_FUTURES_CHAIN_DATES')
         print(data) 
 
+    def test_bds_col_access(self):
+        tester = pybbg.Pybbg()
+        data = tester.bds('MSFT US Equity', 'DVD_HIST_ALL')
+        print(data['Declared Date'])
+
     def test_bds_override(self):
         tester = pybbg.Pybbg()
         data = tester.bds('EDA Comdty', 'FUT_CHAIN_LAST_TRADE_DATES', overrides={'INCLUDE_EXPIRED_CONTRACTS': 'Y'})


### PR DESCRIPTION
they were the type of the bloomberg string wrapper type `Name` and couldn't be accessed with normal strings