### PR TITLE
additional request parameters and date adjustments for bdh

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ New Functions bds and bdp
 		* if one field is used, the second index on the data frame is removed otherwise a multi-index data frame is used
 	* start/end date - end date defaults to today
 	* period selection - default to daily
+	* overrides - a dictionary, keys map to FLDS fields to overrides, values are the override values
+	* other_request_parameters - a dictionary, see `DOCS 2074429 <GO>` page 17 for key/value pairs that are valid here
+	* move_dates_to_period_end - boolean - if true forces WEEKLY to the friday of that week, forces MONTHLY to the last calendar day of that month.
 * bdp(tickers, fields) - similar to excel bdp
 	* tickers - one string or a list of strings
 	* fields - one field or a list of fields

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,12 @@
 from setuptools import setup
 
 setup(name='pybbg',
-      version='0.0.1',
+      version='1.0.0',
       description='Bloomberg Open API with pandas',
       url='https://github.com/kyuni22/pybbg',
       author='kyuni22',
       author_email='kyuni22@gmail.com',
       license='MIT',
       packages=['pybbg'],
+      requires=['dateutil', 'six'],
       zip_safe=False)

--- a/test_pybbg.py
+++ b/test_pybbg.py
@@ -1,6 +1,7 @@
 import unittest
 import pybbg
 import datetime 
+from dateutil.relativedelta import relativedelta
 
 class TestPybbg(unittest.TestCase):
     def test_bdp(self):
@@ -21,7 +22,7 @@ class TestPybbg(unittest.TestCase):
     def test_bds_override(self):
         tester = pybbg.Pybbg()
         data = tester.bds('EDA Comdty', 'FUT_CHAIN_LAST_TRADE_DATES', overrides={'INCLUDE_EXPIRED_CONTRACTS': 'Y'})
-        print(data) 
+        print(data)
 
     def test_bdh(self):
         tester = pybbg.Pybbg()
@@ -48,6 +49,47 @@ class TestPybbg(unittest.TestCase):
         tester = pybbg.Pybbg()
         data = tester.bdh('260555 Equity', ['PX_LAST','PX_BID','PX_ASK'], datetime.datetime.today() + datetime.timedelta(days=-10), datetime.datetime.today())
         print(data)
+
+    def test_bdh_mixed_dates_monthly(self):
+        tester = pybbg.Pybbg()
+        data = tester.bdh(
+            ['FEDL01 Index', 'USSWAP10 Curncy'],
+            'PX_LAST', datetime.date.today() - relativedelta(years=2),
+            datetime.date.today(),
+            'MONTHLY',
+            overrides=dict(
+                CALENDAR_CONVENTION=1 # calendar convention 'calendar' flds rk408
+            ),
+            other_request_parameters=dict(
+                periodicityAdjustment='CALENDAR',
+                nonTradingDayFillMethod='PREVIOUS_VALUE',
+                returnRelativeDate=True
+            ),
+            move_dates_to_period_end=True
+        ).iloc[::-1]
+
+        print(data)
+
+    def test_bdh_mixed_dates_weekly(self):
+        tester = pybbg.Pybbg()
+        data = tester.bdh(
+            ['EONIA Index', 'USSWAP10 Curncy'],
+            'PX_LAST', datetime.date.today() - relativedelta(years=2),
+            datetime.date.today(),
+            'WEEKLY',
+            overrides=dict(
+                CALENDAR_CONVENTION=1 # calendar convention 'calendar' flds rk408
+            ),
+            other_request_parameters=dict(
+                periodicityAdjustment='CALENDAR',
+                nonTradingDayFillMethod='PREVIOUS_VALUE',
+                returnRelativeDate=True
+            ),
+            move_dates_to_period_end=True
+        ).iloc[::-1]
+        print(data)
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I created this PR because of the test cases that were added. Specifically getting historical data for `FEDL01 Index` on different frequencies gives different dates than everything else. There may be other tickers like this.

They get data correctly now and expose more of the Bloomberg API. See also `DOCS 2074429 <GO>` page 17 for things that go into the `other_request_parameters` argument.