### PR TITLE
Update bds to handle null values

### DIFF
--- a/pybbg/pybbg_k.py
+++ b/pybbg/pybbg_k.py
@@ -322,7 +322,10 @@ class Pybbg():
                         for j in range(row.numElements()):
                             e = row.getElement(j)
                             k = str(e.name())
-                            v = e.getValue()
+                            try:
+                                v = e.getValue()
+                            except blpapi.exception.IndexOutOfRangeException:
+                                v = np.NaN
                             if k not in data:
                                 data[k] = list()
 


### PR DESCRIPTION
blpapi.element.getValue() will raise a blpapi.exception.IndexOutOfRangeException if a security field is blank. This fix updates the code to catch the exception and fill the value with np.NaN